### PR TITLE
Update GitHub Actions workflow to use GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
           done
           addons=$(echo ${found_addons[@]} | rev | cut -c 2- | rev)
           echo "Add-ons found: ${addons}"
-          echo "::set-output name=addons::[${addons}]"
+          echo "addons=[${addons}]" >> "$GITHUB_OUTPUT"
 
 
   lint:


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow to use the modern `GITHUB_OUTPUT` environment variable instead of the deprecated `::set-output` command syntax.

## Key Changes
- Replaced `echo "::set-output name=addons::[${addons}]"` with `echo "addons=[${addons}]" >> "$GITHUB_OUTPUT"` in the lint workflow
- This change aligns with GitHub's current best practices for setting workflow outputs

## Implementation Details
The `::set-output` command has been deprecated by GitHub Actions in favor of writing directly to the `$GITHUB_OUTPUT` environment variable. This update ensures the workflow continues to function correctly with current and future versions of GitHub Actions while maintaining the same functionality.

https://claude.ai/code/session_01SAKhW5T4ks1tWv6NBEdZAb