### PR TITLE
Clarify repository purpose and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 
 **DO NOT USE!**
 
-Home Assistant add-ons for testing only!
+This is a personal repository for the author's own Home Assistant add-on testing or usage **only**.
 
-Do **NOT** use anything from this repository in your own add-ons, it does **not** folow any sort of guidelines, this is for testing **only**
+Do **NOT** use anything from this repository in your own add-ons — it does **not** follow any sort of guidelines and exists purely for the author's own testing or usage.
 
-Check the docs and not this repository if you need something <https://developers.home-assistant.io/docs/add-ons>
-
-[Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fludeeus%2Faddon-repository)
+If you need guidance, check the official developer docs instead of this repository: <https://developers.home-assistant.io/docs/add-ons>

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,3 @@
-name: Test add-on repository
+name: Ludeeus' personal add-on repository (testing/usage only)
 url: https://github.com/ludeeus/addon-repository
 maintainer: Ludeeus <ludeeus@ludeeus.dev>


### PR DESCRIPTION
## Summary
Updated repository documentation to more clearly communicate that this is a personal testing repository and should not be used as a reference for add-on development.

## Key Changes
- **README.md**: Rewrote disclaimer text to be more explicit that this is for the author's personal use only, fixed typo ("folow" → "follow"), and removed the add-on repository redirect link
- **repository.yaml**: Updated repository name from generic "Test add-on repository" to "Ludeeus' personal add-on repository (testing/usage only)" for better clarity

## Details
The changes make it clearer to potential users that:
1. This repository is not intended for public use or as a reference implementation
2. Users should consult the official Home Assistant developer documentation instead
3. The repository exists solely for the author's own testing and usage purposes

https://claude.ai/code/session_017n8iCCKuZWzehGetNiujrq