### PR TITLE
Rebrand add-ons to apps throughout repository

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,46 +14,46 @@ permissions: {}
 
 jobs:
   find:
-    name: Find add-ons
+    name: Find apps
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
-      addons: ${{ steps.addons.outputs.addons }}
+      apps: ${{ steps.apps.outputs.apps }}
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - name: 🔍 Find add-on directories
-        id: addons
+      - name: 🔍 Find app directories
+        id: apps
         run: |
-          declare -a found_addons
-          for addon in $(find ./ -name config.yaml | cut -d "/" -f2 | sort -u); do
-            found_addons+=("\"${addon}\",");
+          declare -a found_apps
+          for app in $(find ./ -name config.yaml | cut -d "/" -f2 | sort -u); do
+            found_apps+=("\"${app}\",");
           done
-          addons=$(echo ${found_addons[@]} | rev | cut -c 2- | rev)
-          echo "Add-ons found: ${addons}"
-          echo "addons=[${addons}]" >> "$GITHUB_OUTPUT"
+          apps=$(echo ${found_apps[@]} | rev | cut -c 2- | rev)
+          echo "Apps found: ${apps}"
+          echo "apps=[${apps}]" >> "$GITHUB_OUTPUT"
 
 
   lint:
-    name: Lint add-on ${{ matrix.path }}
+    name: Lint app ${{ matrix.path }}
     runs-on: ubuntu-latest
     needs: find
     permissions:
       contents: read
     strategy:
       matrix:
-        path: ${{ fromJson(needs.find.outputs.addons) }}
+        path: ${{ fromJson(needs.find.outputs.apps) }}
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - name: 🚀 Run Home Assistant Add-on Lint
+      - name: 🚀 Run Home Assistant App Lint
         uses: frenck/action-addon-linter@f995494fd84fae6310d23617e66d0e37de4f14eb # v2.21.0
         with:
           path: "./${{ matrix.path }}"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# addon-repository
+# app-repository
 
 **DO NOT USE!**
 
-This is a personal repository for the author's own Home Assistant add-on testing or usage **only**.
+This is a personal repository for the author's own Home Assistant app testing or usage **only**.
 
-Do **NOT** use anything from this repository in your own add-ons — it does **not** follow any sort of guidelines and exists purely for the author's own testing or usage.
+Do **NOT** use anything from this repository in your own apps — it does **not** follow any sort of guidelines and exists purely for the author's own testing or usage.
 
 If you need guidance, check the official developer docs instead of this repository: <https://developers.home-assistant.io/docs/add-ons>

--- a/brotli/Dockerfile
+++ b/brotli/Dockerfile
@@ -3,7 +3,7 @@ FROM $BUILD_FROM
 
 ENV LANG C.UTF-8
 
-# Copy data for add-on
+# Copy data for app
 COPY app /app
 COPY requirements.txt requirements.txt 
 

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,3 @@
-name: Ludeeus' personal add-on repository (testing/usage only)
+name: Ludeeus' personal app repository (testing/usage only)
 url: https://github.com/ludeeus/addon-repository
 maintainer: Ludeeus <ludeeus@ludeeus.dev>

--- a/upload/Dockerfile
+++ b/upload/Dockerfile
@@ -3,7 +3,7 @@ FROM $BUILD_FROM
 
 ENV LANG C.UTF-8
 
-# Copy data for add-on
+# Copy data for app
 COPY app /app
 COPY requirements.txt requirements.txt 
 


### PR DESCRIPTION
## Summary
This PR updates all references from "add-on" terminology to "app" terminology throughout the repository, reflecting a rebranding effort across documentation, workflows, and Dockerfiles.

## Key Changes
- **GitHub Actions Workflow**: Updated `.github/workflows/lint.yml` to use "app" instead of "add-on" in:
  - Job names and step descriptions
  - Variable names (`addons` → `apps`)
  - Output references and echo messages
  - Matrix strategy configuration
  - Linter action description

- **Documentation**: Updated `README.md` to reflect the new "app" terminology:
  - Repository title changed from "addon-repository" to "app-repository"
  - Updated description text to reference "apps" instead of "add-ons"
  - Maintained link to official developer documentation

- **Configuration**: Updated `repository.yaml` to change the repository name from "add-on repository" to "app repository"

- **Dockerfiles**: Updated comments in `brotli/Dockerfile` and `upload/Dockerfile` to reference "app" instead of "add-on"

## Implementation Details
All changes are consistent terminology updates with no functional code modifications. The linter action itself still references the add-on linter tool, as that is the external action name and remains unchanged.

https://claude.ai/code/session_01AafTeLfQiug6NHd6dcqUKx